### PR TITLE
Add optional MaxRepoCreation field to EditUserOption

### DIFF
--- a/admin_user.go
+++ b/admin_user.go
@@ -42,6 +42,7 @@ type EditUserOption struct {
 	Admin            *bool  `json:"admin"`
 	AllowGitHook     *bool  `json:"allow_git_hook"`
 	AllowImportLocal *bool  `json:"allow_import_local"`
+	MaxRepoCreation  *int   `json:"max_repo_creation"`
 }
 
 func (c *Client) AdminEditUser(user string, opt EditUserOption) error {


### PR DESCRIPTION
Adds an optional `max_repo_creation` field to the EditUserOption form. Related to gogits/gogs#2781