### PR TITLE
Add AddCollaborator API Endpoint

### DIFF
--- a/repo_collaborator.go
+++ b/repo_collaborator.go
@@ -1,0 +1,24 @@
+// Copyright 2016 The Gogs Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gogs
+
+import (
+	"encoding/json"
+	"bytes"
+	"fmt"
+)
+
+type AddCollaboratorOption struct {
+	Permission *string `json:"permission"`
+}
+
+func (c *Client) AddCollaborator(user, repo, collaborator string, opt AddCollaboratorOption) error {
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return err
+	}
+	_, err = c.getResponse("PUT", fmt.Sprintf("/repos/%s/%s/collaborators/%s", user, repo, collaborator), nil, bytes.NewReader(body))
+	return err
+}


### PR DESCRIPTION
Adds the AddCollaborator API Endpoint. Related to gogits/gogs#2780