### PR TITLE
Fix typos in create issue comment and edit issue comment API URLs

### DIFF
--- a/issue_comment.go
+++ b/issue_comment.go
@@ -38,7 +38,7 @@ func (c *Client) CreateIssueComment(owner, repo string, index int64, opt CreateI
 		return nil, err
 	}
 	comment := new(Comment)
-	return comment, c.getParsedResponse("POST", fmt.Sprintf("/repos/:%s/:%s/issues/%d/comments", owner, repo, index), jsonHeader, bytes.NewReader(body), comment)
+	return comment, c.getParsedResponse("POST", fmt.Sprintf("/repos/%s/%s/issues/%d/comments", owner, repo, index), jsonHeader, bytes.NewReader(body), comment)
 }
 
 // EditIssueCommentOption is option when editing an issue comment.
@@ -53,5 +53,5 @@ func (c *Client) EditIssueComment(owner, repo string, index, commentID int64, op
 		return nil, err
 	}
 	comment := new(Comment)
-	return comment, c.getParsedResponse("PATCH", fmt.Sprintf("/repos/:%s/:%s/issues/%d/comments/%d", owner, repo, index, commentID), jsonHeader, bytes.NewReader(body), comment)
+	return comment, c.getParsedResponse("PATCH", fmt.Sprintf("/repos/%s/%s/issues/%d/comments/%d", owner, repo, index, commentID), jsonHeader, bytes.NewReader(body), comment)
 }


### PR DESCRIPTION
This is minor changes to issue_comment.go. There are extraneous :'s in the URL called to create an issue comment and to edit an issue comment.

Prior to this fix, these functions would return 404 error.