### PR TITLE
Set description max size to 512

### DIFF
--- a/repo.go
+++ b/repo.go
@@ -64,7 +64,7 @@ func (c *Client) ListOrgRepos(org string) ([]*Repository, error) {
 
 type CreateRepoOption struct {
 	Name        string `json:"name" binding:"Required;AlphaDashDot;MaxSize(100)"`
-	Description string `json:"description" binding:"MaxSize(255)"`
+	Description string `json:"description" binding:"MaxSize(512)"`
 	Private     bool   `json:"private"`
 	Unlisted    bool   `json:"unlisted"`
 	AutoInit    bool   `json:"auto_init"`


### PR DESCRIPTION
Set description max size to 512 when creating a repository.

This is the same limit as the one in the form when creating a repo: https://github.com/gogs/gogs/blob/main/internal/form/repo.go#L32