### PR TITLE
Extend api

### DIFF
--- a/admin_user.go
+++ b/admin_user.go
@@ -66,3 +66,26 @@ func (c *Client) AdminCreateUserPublicKey(user string, opt CreateKeyOption) (*Pu
 	key := new(PublicKey)
 	return key, c.getParsedResponse("POST", fmt.Sprintf("/admin/users/%s/keys", user), jsonHeader, bytes.NewReader(body), key)
 }
+
+func (c *Client) AdminListUserEmails(user string) ([]*Email, error) {
+	emails := make([]*Email, 0, 3)
+	return emails, c.getParsedResponse("GET", fmt.Sprintf("/admin/users/%s/emails", user), nil, nil, &emails)
+}
+
+func (c *Client) AdminAddUserEmail(user string, opt CreateEmailOption) ([]*Email, error) {
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, err
+	}
+	emails := make([]*Email, 0, 3)
+	return emails, c.getParsedResponse("POST", fmt.Sprintf("/admin/users/%s/emails", user), jsonHeader, bytes.NewReader(body), emails)
+}
+
+func (c *Client) AdminDeleteUserEmail(user string, opt CreateEmailOption) error {
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return err
+	}
+	_, err = c.getResponse("DELETE", fmt.Sprintf("/admin/users/%s/emails", user), jsonHeader, bytes.NewReader(body))
+	return err
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,4 @@
+module github.com/gogs/go-gogs-client
+
+go 1.18
+

--- a/repo.go
+++ b/repo.go
@@ -131,6 +131,23 @@ func (c *Client) MigrateRepo(opt MigrateRepoOption) (*Repository, error) {
 	return repo, c.getParsedResponse("POST", "/repos/migrate", jsonHeader, bytes.NewReader(body), repo)
 }
 
+type EditRepoOption struct {
+	Description   *string `json:"description" binding:"MaxSize(255)"`
+	Private       *bool   `json:"private"`
+	Unlisted      *bool   `json:"unlisted"`
+	DefaultBranch *string `json:"default_branch"`
+}
+
+// EditRepo modifies a repository.
+func (c *Client) EditRepo(owner, repo string, opt EditRepoOption) (*Repository, error) {
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, err
+	}
+	modRepo := new(Repository)
+	return modRepo, c.getParsedResponse("PATCH", fmt.Sprintf("/repos/%s/%s", owner, repo), jsonHeader, bytes.NewReader(body), modRepo)
+}
+
 type EditIssueTrackerOption struct {
 	EnableIssues          *bool   `json:"enable_issues"`
 	EnableExternalTracker *bool   `json:"enable_external_tracker"`

--- a/user.go
+++ b/user.go
@@ -16,6 +16,8 @@ type User struct {
 	FullName  string `json:"full_name"`
 	Email     string `json:"email"`
 	AvatarUrl string `json:"avatar_url"`
+	Location  string `json:"location"`
+	Website   string `json:"website"`
 }
 
 func (c *Client) GetUserInfo(user string) (*User, error) {


### PR DESCRIPTION
Gogs REST API is missing some functionality with resp. to the Web frontend. The changes here covers:

* Support for modifying a repos 
    * description
    * private status
    * listed status
    * default branch
* Updating the list of E-Mails for a given user as admin
* Updating a users Location and website

These changes cover the client side, the server-side changes are covered in a seperate PR on the gogs repo 